### PR TITLE
Rails 4.2 support.

### DIFF
--- a/lib/acts_as_bits.rb
+++ b/lib/acts_as_bits.rb
@@ -68,7 +68,11 @@ module ActsAsBits
               end
 
               def #{name}=(v)
-                v = ActiveRecord::ConnectionAdapters::Column.value_to_boolean(v) ? ?1 : ?0
+                if defined?(ActiveRecord::ConnectionAdapters::Column::TRUE_VALUES)
+                  v = ActiveRecord::ConnectionAdapters::Column::TRUE_VALUES.include?(v) ? ?1 : ?0
+                else
+                  v = ActiveRecord::ConnectionAdapters::Column.value_to_boolean(v) ? ?1 : ?0
+                end
 
                 # expand target string automatically
                 if #{composed_name}.size < #{singular_name}_names.size


### PR DESCRIPTION
Rails 4.2 では ActiveRecord::ConnectionAdapters::Column の value_to_boolean が無くなるようなので、代わりに TRUE_VALUES という Set の中に入っている boolean っぽい値に含まれるかどうかで判定するようにしました。
